### PR TITLE
Update return type to tuple

### DIFF
--- a/youtube_title_parse/parse.py
+++ b/youtube_title_parse/parse.py
@@ -31,9 +31,9 @@ def get_artist_title(text, options={}):
         },
     )
     if result:
-        return "%s - %s" % (result[0], result[1])
+        return result[0], result[1]
     else:
-        return text
+        return None
 
 
 def process(args):


### PR DESCRIPTION
## Changes
### Update return type to tuple
Update the return type to be similar to a tuple (similar to [`get-artist-title`](https://github.com/goto-bus-stop/get-artist-title)). This way, consumers of this package don't have to parse the string again to get artist and title.

Resolves #1, #3 