### PR TITLE
Add unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ Setup script for youtube_title_parse
 """
 from setuptools import setup, find_packages
 
+tests_require = ["six"]
+
 setup(
     name="youtube_title_parse",
     description="Parse the title of a YouTube video to try and get artist & song name",
@@ -27,6 +29,7 @@ setup(
     keywords=["youtube", "title", "metadata", "parse", "music"],
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     install_requires=[],
+    tests_require=tests_require,
     entry_points={
         "console_scripts": ["youtube_title_parse=youtube_title_parse.parse:main"],
     },

--- a/test/meta.py
+++ b/test/meta.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import os
+from youtube_title_parse import get_artist_title
+
+
+class TestSequenceMeta(type):
+    def __new__(mcs, name, bases, attrs):
+        def gen_test(input, expected):
+            def test(self):
+                artist, title = get_artist_title(input) or (None, None)
+                self.assertEqual(artist, expected[0])
+                self.assertEqual(title, expected[1])
+
+            return test
+
+        if "test_cases" in attrs and "test_type" in attrs:
+            for idx, test in enumerate(attrs["test_cases"]):
+                test_kind = os.path.splitext(os.path.basename(attrs["test_type"]))[0]
+                test_name = "%s_%d" % (test_kind, idx + 1)
+                attrs[test_name] = gen_test(test["input"], test["expected"])
+        return type.__new__(mcs, name, bases, attrs)

--- a/test/test_fluff.py
+++ b/test/test_fluff.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import TestSequenceMeta
+
+tests = [
+    {
+        "input": "Rush – Moving Pictures (Full Album)",
+        "expected": ["Rush", "Moving Pictures"],
+    },
+    {
+        "input": "Rush - Moving Pictures (album)",
+        "expected": ["Rush", "Moving Pictures"],
+    },
+    {
+        "input": "Rush - Moving Pictures (Official Album)",
+        "expected": ["Rush", "Moving Pictures"],
+    },
+    {
+        "input": "Rush - Moving Pictures (Full Album) (Official)",
+        "expected": ["Rush", "Moving Pictures"],
+    },
+    {
+        "input": "FILMMAKER - ETERNAL RETURN [FULL ALBUM]",
+        "expected": ["FILMMAKER", "ETERNAL RETURN"],
+    },
+    {
+        "input": "Dua Lipa - New Rules (Official Music Video) **NEW**",
+        "expected": ["Dua Lipa", "New Rules"],
+    },
+    {
+        "input": "Muse — The 2nd Law (Full Album) [HD]",
+        "expected": ["Muse", "The 2nd Law"],
+    },
+]
+
+
+class TestSequence(with_metaclass(TestSequenceMeta, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_jypentertainment.py
+++ b/test/test_jypentertainment.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import TestSequenceMeta
+
+# K-pop song titles taken from JYP entertainment's Most Popular page:
+# https://www.youtube.com/user/jypentertainment/videos?flow=grid&view=0&sort=p
+# jypentertainment uses a title format like:
+# Artist "Title" Fluff
+tests = [
+    # This one is not so fun because there is a separator (-) inside the quotes,
+    # and separators are usually tried first.
+    {
+        "input": 'TWICE(트와이스) "OOH-AHH하게(Like OOH-AHH)" M/V',
+        "expected": ["TWICE(트와이스)", "OOH-AHH하게(Like OOH-AHH)"],
+    },
+    {"input": 'GOT7 "Just right(딱 좋아)" M/V', "expected": ["GOT7", "Just right(딱 좋아)"]},
+    {
+        "input": "miss A “Only You(다른 남자 말고 너)” M/V",
+        "expected": ["miss A", "Only You(다른 남자 말고 너)"],
+    },
+    {"input": 'GOT7 "If You Do(니가 하면)" M/V', "expected": ["GOT7", "If You Do(니가 하면)"]},
+    {"input": 'GOT7 "A" M/V', "expected": ["GOT7", "A"]},
+    {
+        "input": 'J.Y. Park(박진영) "Who\'s your mama?(어머님이 누구니) (feat. Jessi)" M/V',
+        "expected": ["J.Y. Park(박진영)", "Who's your mama?(어머님이 누구니) (feat. Jessi)"],
+    },
+    {
+        "input": 'GOT7 "Girls Girls Girls" M/V',
+        "expected": ["GOT7", "Girls Girls Girls"],
+    },
+    {
+        "input": "GOT7 “Stop stop it(하지하지마)” M/V",
+        "expected": ["GOT7", "Stop stop it(하지하지마)"],
+    },
+    {
+        "input": "2PM “GO CRAZY!(미친거 아니야?)” M/V",
+        "expected": ["2PM", "GO CRAZY!(미친거 아니야?)"],
+    },
+    {
+        "input": '2PM "A.D.T.O.Y.(하.니.뿐.)" M/V',
+        "expected": ["2PM", "A.D.T.O.Y.(하.니.뿐.)"],
+    },
+    {"input": "2PM “My House(우리집)” M/V", "expected": ["2PM", "My House(우리집)"]},
+    {"input": "GOT7 “Fly” M/V", "expected": ["GOT7", "Fly"]},
+    {
+        "input": 'Wonder Girls "I Feel You" M/V',
+        "expected": ["Wonder Girls", "I Feel You"],
+    },
+    {
+        "input": 'GOT7 "I Like You(난 니가 좋아)" Dance Practice',
+        "expected": ["GOT7", "I Like You(난 니가 좋아)"],
+    },
+    {
+        "input": 'GOT7 "Just right(딱 좋아)" Dance Practice #2 (Just Crazy Boyfriend Ver.)',
+        "expected": ["GOT7", "Just right(딱 좋아)"],
+    },
+    {
+        "input": 'GOT7 "Stop stop it(하지하지마)" Dance Practice',
+        "expected": ["GOT7", "Stop stop it(하지하지마)"],
+    },
+    {
+        "input": '2PM "Comeback When You Hear This Song(이 노래를 듣고 돌아와)" M/V',
+        "expected": ["2PM", "Comeback When You Hear This Song(이 노래를 듣고 돌아와)"],
+    },
+    {
+        "input": 'Sunmi(선미) "Full Moon(보름달)" M/V',
+        "expected": ["Sunmi(선미)", "Full Moon(보름달)"],
+    },
+    {
+        "input": 'GOT7 "Magnetic(너란 걸)" Dance Practice',
+        "expected": ["GOT7", "Magnetic(너란 걸)"],
+    },
+    {
+        "input": 'miss A "Only You(다른 남자 말고 너)" Dance Practice',
+        "expected": ["miss A", "Only You(다른 남자 말고 너)"],
+    },
+    {
+        "input": "Baek A Yeon(백아연) “Shouldn’t Have…(이럴거면 그러지말지) (Feat. Young K)” M/V",
+        "expected": ["Baek A Yeon(백아연)", "Shouldn’t Have…(이럴거면 그러지말지) (Feat. Young K)"],
+    },
+    {"input": 'DAY6 "Congratulations" M/V', "expected": ["DAY6", "Congratulations"]},
+    {"input": 'Wonder Girls "Tell me" M/V', "expected": ["Wonder Girls", "Tell me"]},
+    {
+        "input": 'GOT7 "Confession Song(고백송)" M/V',
+        "expected": ["GOT7", "Confession Song(고백송)"],
+    },
+    {
+        "input": 'GOT7 "Stop stop it(하지하지마)" Dance Practice #2 (Crazy Boyfriend Ver.)',
+        "expected": ["GOT7", "Stop stop it(하지하지마)"],
+    },
+    {"input": 'GOT7 "A" Dance Practice', "expected": ["GOT7", "A"]},
+    {
+        "input": 'GOT7 "Girls Girls Girls" Dance Practice #2',
+        "expected": ["GOT7", "Girls Girls Girls"],
+    },
+    {
+        "input": 'GOT7 "If You Do(니가 하면)" Dance Practice',
+        "expected": ["GOT7", "If You Do(니가 하면)"],
+    },
+]
+
+
+class TestSequence(with_metaclass(TestSequenceMeta, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_remove_file_extensions.py
+++ b/test/test_remove_file_extensions.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import TestSequenceMeta
+
+tests = [
+    # https://youtu.be/A2RwHnfI2y8
+    {
+        "input": "Ga-In (가인) - Nostalgia (노스텔지아) - Lyrics [Hangul+Translation] .mov",
+        "expected": ["Ga-In (가인)", "Nostalgia (노스텔지아)"],
+    },
+    # https://www.youtube.com/watch?v=PYBuIwuD1DA
+    {"input": "show me - B-free.m4v", "expected": ["show me", "B-free"]},
+    # https://www.youtube.com/watch?v=5hINYNZslP0
+    {
+        "input": "성시경 Sung Si Kyung - 내게 오는 길.mp4",
+        "expected": ["성시경 Sung Si Kyung", "내게 오는 길"],
+    },
+    # Things that are NOT file extensions are not removed:
+    # https://www.youtube.com/watch?v=E2yLg9iW1_0
+    {"input": "에이핑크 - Mr.chu", "expected": ["에이핑크", "Mr.chu"]},
+    # https://www.youtube.com/watch?v=P1Oya1PqKFc
+    {
+        "input": "Far East Movement - Live My Life (Feat. Justin Bieber) cover by J.Fla",
+        "expected": [
+            "Far East Movement",
+            "Live My Life (Feat. Justin Bieber) cover by J.Fla",
+        ],
+    },
+    # https://www.youtube.com/watch?v=rnQBF2CIygg
+    # Thing that ends in a file extension without a preceding `.`:
+    {
+        "input": "Baka Oppai - A Piece Of Toast",
+        "expected": ["Baka Oppai", "A Piece Of Toast"],
+    },
+]
+
+
+class TestSequence(with_metaclass(TestSequenceMeta, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_separators.py
+++ b/test/test_separators.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import TestSequenceMeta
+
+tests = [
+    # https://www.youtube.com/watch?v=dYnDCHUzzaY
+    # ":" is a possible separator, but should not be used in this case.
+    {
+        "input": 'HA:TFELT [핫펠트(예은)] "Truth" M/V',
+        # Ideal would be to include the Hangul but it's in
+        # [] which means it's deleted for now.
+        "expected": ["HA:TFELT", "Truth"],
+        "optional": True,
+    },
+    # https://www.youtube.com/watch?v=Qk52ypnGs68
+    # "-" is a possible separator, but should not be used in this case.
+    {
+        "input": 'T-ARA[티아라] "NUMBER NINE [넘버나인]" M/V',
+        "expected": ["T-ARA", "NUMBER NINE"],
+        "optional": True,
+    },
+    # https://www.youtube.com/watch?v=aeo_nWsu5cs
+    {
+        "input": "[MV] YOUNHA(윤하) _ Get It?(알아듣겠지) (Feat. HA:TFELT, CHEETAH(치타))",
+        "expected": ["YOUNHA(윤하)", "Get It?(알아듣겠지) (Feat. HA:TFELT, CHEETAH(치타))"],
+    },
+]
+
+
+class TestSequence(with_metaclass(TestSequenceMeta, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_simple.py
+++ b/test/test_simple.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import TestSequenceMeta
+
+tests = [
+    # https://youtu.be/hn4EIv1-uz0
+    {
+        "input": "Boats & BIrds - Gregory & the Hawk",
+        "expected": ["Boats & BIrds", "Gregory & the Hawk"],
+    },
+    # https://youtu.be/JoC3PUBmhFs
+    {
+        "input": "Sum 41 - In Too Deep (Official Video)",
+        "expected": ["Sum 41", "In Too Deep"],
+    },
+    # Punctuation mark at the end
+    # https://youtu.be/fz3jLeDvpu4
+    {"input": "FEMM - PoW! (Music Video)", "expected": ["FEMM", "PoW!"]},
+    # Song with a separator in its name (-), and unparenthesised "official video"
+    # https://youtu.be/ti1W7Zu8j9k
+    {
+        "input": "The Wombats - Anti-D Official Video",
+        "expected": ["The Wombats", "Anti-D"],
+    },
+    # Words containing "…ver" should not be removed--only standalone "ver(.)".
+    {"input": "4MINUTE – Whatever", "expected": ["4MINUTE", "Whatever"]},
+    {"input": "4MINUTE – Whatever (Test Ver)", "expected": ["4MINUTE", "Whatever"]},
+    # Quoted song title
+    # https://www.youtube.com/watch?v=VVF0zxw4tuM
+    {"input": 'Low Roar - "Half Asleep"', "expected": ["Low Roar", "Half Asleep"]},
+    # Quoted song title _and_ "official video"
+    # https://www.youtube.com/watch?v=qsWl1--Niyg
+    {
+        "input": "4MINUTE - 'Volume Up' (Official Music Video)",
+        "expected": ["4MINUTE", "Volume Up"],
+    },
+    # Things with punctuation in front
+    # https://www.youtube.com/watch?v=zsF5y1XhGuA
+    {
+        "input": "...AND YOU WILL KNOW US BY THE TRAIL OF DEAD - Summer Of All Dead Souls",
+        "expected": [
+            "...AND YOU WILL KNOW US BY THE TRAIL OF DEAD",
+            "Summer Of All Dead Souls",
+        ],
+    },
+    # File extensions _and_ "official video"
+    # https://www.youtube.com/watch?v=ZPjwdiD24Kg
+    {
+        "input": "Low Roar - Give Up (Official Video).mov",
+        "expected": ["Low Roar", "Give Up"],
+    },
+    # A separator with _only_ fluff like "MV" on one side
+    # https://www.youtube.com/watch?v=yRMvzyN-__Q
+    {
+        "input": "MV_Planet Shiver_Rainbow [feat. Crush]",
+        "expected": ["Planet Shiver", "Rainbow"],
+    },
+    # "Official MV"
+    # https://www.youtube.com/watch?v=qSKPj--tyiM
+    {
+        "input": "임정희 Lim Jeong Hee - I.O.U Official MV",
+        "expected": ["임정희 Lim Jeong Hee", "I.O.U"],
+    },
+    # 4K, see https://github.com/goto-bus-stop/get-artist-title/issues/20
+    {
+        "input": "Big Limit [@RealBigLimit] - Samurai Jack [Music Video] (4K)",
+        "expected": ["Big Limit", "Samurai Jack"],
+    },
+    # sizes like 720p
+    {
+        "input": "Big Limit [@RealBigLimit] - Samurai Jack [Music Video] (720p)",
+        "expected": ["Big Limit", "Samurai Jack"],
+    },
+]
+
+
+class TestSequence(with_metaclass(TestSequenceMeta, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_subpop2014.py
+++ b/test/test_subpop2014.py
@@ -1,0 +1,291 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import TestSequenceMeta
+
+tests = [
+    {
+        "input": "clipping. - Inside Out [OFFICIAL VIDEO]",
+        "expected": ["clipping.", "Inside Out"],
+    },
+    {
+        "input": "King Tuff - Black Moon Spell [OFFICIAL VIDEO]",
+        "expected": ["King Tuff", "Black Moon Spell"],
+    },
+    {
+        "input": "Sleater-Kinney - Bury Our Friends (feat. Miranda July)",
+        "expected": ["Sleater-Kinney", "Bury Our Friends (feat. Miranda July)"],
+    },
+    {
+        "input": "Pissed Jeans - Boring Girls [OFFICIAL VIDEO]",
+        "expected": ["Pissed Jeans", "Boring Girls"],
+    },
+    {
+        "input": "Father John Misty - Chateau Lobby #4 (in C for Two Virgins) [OFFICIAL VIDEO]",
+        "expected": ["Father John Misty", "Chateau Lobby #4 (in C for Two Virgins)"],
+    },
+    {
+        "input": "Chad VanGaalen - Monster [OFFICIAL VIDEO]",
+        "expected": ["Chad VanGaalen", "Monster"],
+    },
+    {
+        "input": "Luluc - Tangled Heart  [OFFICIAL VIDEO]",
+        "expected": ["Luluc", "Tangled Heart"],
+    },
+    {
+        "input": "J Mascis - Every Morning [OFFICIAL VIDEO]",
+        "expected": ["J Mascis", "Every Morning"],
+    },
+    {
+        "input": "THEESatisfaction - Recognition  (not the video)",
+        "expected": ["THEESatisfaction", "Recognition"],
+    },
+    {
+        "input": "Goat - Hide from the Sun [OFFICIAL VIDEO]",
+        "expected": ["Goat", "Hide from the Sun"],
+    },
+    {
+        "input": "Shabazz Palaces - Motion Sickness [OFFICIAL VIDEO]",
+        "expected": ["Shabazz Palaces", "Motion Sickness"],
+    },
+    {
+        "input": "The Afghan Whigs - Lost in the Woods [OFFICIAL VIDEO]",
+        "expected": ["The Afghan Whigs", "Lost in the Woods"],
+    },
+    {
+        "input": "The Head and the Heart - Another Story [OFFICIAL VIDEO]",
+        "expected": ["The Head and the Heart", "Another Story"],
+    },
+    {
+        "input": "Washed Out - Weightless [OFFICIAL VIDEO]",
+        "expected": ["Washed Out", "Weightless"],
+    },
+    {
+        "input": "Deaf Wish - Cool Comment [OFFICIAL VIDEO]",
+        "expected": ["Deaf Wish", "Cool Comment"],
+    },
+    {
+        "input": "Father John Misty - Bored In The USA",
+        "expected": ["Father John Misty", "Bored In The USA"],
+    },
+    {
+        "input": "Flake Music - Spanway Hits  (not the video)",
+        "expected": ["Flake Music", "Spanway Hits"],
+    },
+    {
+        "input": "Sleater-Kinney - Surface Envy",
+        "expected": ["Sleater-Kinney", "Surface Envy"],
+    },
+    {
+        "input": "clipping. - Get Up [OFFICIAL VIDEO]",
+        "expected": ["clipping.", "Get Up"],
+    },
+    {"input": "King Tuff - Headbanger", "expected": ["King Tuff", "Headbanger"]},
+    {
+        "input": "Shabazz Palaces - #CAKE [OFFICIAL VIDEO]",
+        "expected": ["Shabazz Palaces", "#CAKE"],
+    },
+    {
+        "input": "The Afghan Whigs - Every Little Thing She Does is Magic (cover of The Police)",
+        "expected": [
+            "The Afghan Whigs",
+            "Every Little Thing She Does is Magic (cover of The Police)",
+        ],
+    },
+    {
+        "input": "Mirel Wagner - The Dirt [OFFICIAL VIDEO]",
+        "expected": ["Mirel Wagner", "The Dirt"],
+    },
+    {
+        "input": "Avi Buffalo - Memories of You (not the video)",
+        "expected": ["Avi Buffalo", "Memories of You"],
+    },
+    {"input": "Goat - Words (not the video)", "expected": ["Goat", "Words"]},
+    {
+        "input": "clipping. - Story 2 [OFFICIAL VIDEO]",
+        "expected": ["clipping.", "Story 2"],
+    },
+    {
+        "input": "Shabazz Palaces - #CAKE (Animal Collective Premature Deflirt Mix)",
+        "expected": [
+            "Shabazz Palaces",
+            "#CAKE (Animal Collective Premature Deflirt Mix)",
+        ],
+    },
+    {"input": "Flake Music - The Shins", "expected": ["Flake Music", "The Shins"]},
+    {
+        "input": "J Mascis - Wide Awake (not the video)",
+        "expected": ["J Mascis", "Wide Awake"],
+    },
+    {
+        "input": "The Head and the Heart - Let's Be Still [OFFICIAL VIDEO]",
+        "expected": ["The Head and the Heart", "Let's Be Still"],
+    },
+    {
+        "input": "Luluc - Small Window [OFFICIAL VIDEO]",
+        "expected": ["Luluc", "Small Window"],
+    },
+    {
+        "input": "Lyla Foy - Honeymoon [OFFICIAL VIDEO]",
+        "expected": ["Lyla Foy", "Honeymoon"],
+    },
+    {
+        "input": "Avi Buffalo - So What [OFFICIAL VIDEO]",
+        "expected": ["Avi Buffalo", "So What"],
+    },
+    {
+        "input": "clipping. - Body & Blood [CENSORED VERSION of OFFICIAL VIDEO]",
+        "expected": ["clipping.", "Body & Blood"],
+    },
+    {
+        "input": "King Tuff - Eyes of the Muse (not the video)",
+        "expected": ["King Tuff", "Eyes of the Muse"],
+    },
+    {"input": "Deaf Wish - St Vincent's", "expected": ["Deaf Wish", "St Vincent's"]},
+    {
+        "input": "The Afghan Whigs - Matamoros [OFFICIAL VIDEO]",
+        "expected": ["The Afghan Whigs", "Matamoros"],
+    },
+    {
+        "input": "Dum Dum Girls - Too True To Be Good [OFFICIAL VIDEO]",
+        "expected": ["Dum Dum Girls", "Too True To Be Good"],
+    },
+    {
+        "input": "J Mascis - Fade Into You (a Mazzy Star cover)",
+        "expected": ["J Mascis", "Fade Into You (a Mazzy Star cover)"],
+    },
+    {
+        "input": "Shabazz Palaces - Forerunner Foray",
+        "expected": ["Shabazz Palaces", "Forerunner Foray"],
+    },
+    {
+        "input": "Lee Bains III & The Glory Fires - The Company Man [OFFICIAL VIDEO]",
+        "expected": ["Lee Bains III & The Glory Fires", "The Company Man"],
+    },
+    {
+        "input": "The Postal Service - Nothing Better [LIVE]",
+        "expected": ["The Postal Service", "Nothing Better"],
+    },
+    {
+        "input": "Rose Windows - There is a Light [OFFICIAL VIDEO]",
+        "expected": ["Rose Windows", "There is a Light"],
+    },
+    {
+        "input": "Mirel Wagner - Oak Tree [OFFICIAL VIDEO]",
+        "expected": ["Mirel Wagner", "Oak Tree"],
+    },
+    {
+        "input": "clipping. - Work Work (feat. Cocc Pistol Cree) [OFFICIAL VIDEO]",
+        "expected": ["clipping.", "Work Work (feat. Cocc Pistol Cree)"],
+    },
+    {
+        "input": "Dum Dum Girls - Rimbaud Eyes [OFFICIAL VIDEO]",
+        "expected": ["Dum Dum Girls", "Rimbaud Eyes"],
+    },
+    {
+        "input": "The Head and the Heart - Summertime [OFFICIAL VIDEO]",
+        "expected": ["The Head and the Heart", "Summertime"],
+    },
+    {
+        "input": "Shabazz Palaces - They Come In Gold (not the video)",
+        "expected": ["Shabazz Palaces", "They Come In Gold"],
+    },
+    {
+        "input": "Lee Bains III & The Glory Fires - The Weeds Downtown (not the video)",
+        "expected": ["Lee Bains III & The Glory Fires", "The Weeds Downtown"],
+    },
+    {
+        "input": "Constantines - Young Lions (not the video)",
+        "expected": ["Constantines", "Young Lions"],
+    },
+    {
+        "input": "The Afghan Whigs - The Lottery (not the video)",
+        "expected": ["The Afghan Whigs", "The Lottery"],
+    },
+    {"input": "Luluc - Without a Face", "expected": ["Luluc", "Without a Face"]},
+    {
+        "input": "Lyla Foy - Feather Tongue [OFFICIAL VIDEO]",
+        "expected": ["Lyla Foy", "Feather Tongue"],
+    },
+    {
+        "input": "Dum Dum Girls -  Are You Okay? [OFFICIAL SHORT FILM VIDEO]",
+        "expected": ["Dum Dum Girls", "Are You Okay?"],
+    },
+    {
+        "input": "THUMPERS - Lungs (Originally Performed by Chvrches) [not the video]",
+        "expected": ["THUMPERS", "Lungs (Originally Performed by Chvrches)"],
+    },
+    {
+        "input": "Washed Out - All I Know [Moby Remix] (not the video)",
+        "expected": ["Washed Out", "All I Know [Moby Remix]"],
+    },
+    {
+        "input": "Goat - Dreambuilding (not the video)",
+        "expected": ["Goat", "Dreambuilding"],
+    },
+    {
+        "input": "Lee Bains III & The Glory Fires - The Company Man (not the video)",
+        "expected": ["Lee Bains III & The Glory Fires", "The Company Man"],
+    },
+    {
+        "input": "The Afghan Whigs - Algiers [OFFICIAL VIDEO]",
+        "expected": ["The Afghan Whigs", "Algiers"],
+    },
+    {
+        "input": 'Shearwater - Black Is The Color  (from the "Colors" episode of Radiolab)',
+        "expected": [
+            "Shearwater",
+            'Black Is The Color (from the "Colors" episode of Radiolab)',
+        ],
+        "optional": True,
+    },
+    {
+        "input": "The Notwist - Kong [OFFICIAL VIDEO]",
+        "expected": ["The Notwist", "Kong"],
+    },
+    {
+        "input": "Death Vessel - Mercury Dime [OFFICIAL VIDEO]",
+        "expected": ["Death Vessel", "Mercury Dime"],
+    },
+    {
+        "input": "The Ruby Suns - Desert Of Pop [OFFICIAL VIDEO]",
+        "expected": ["The Ruby Suns", "Desert Of Pop"],
+    },
+    {
+        "input": "THUMPERS - Unkinder (A Tougher Love) [OFFICIAL VIDEO]",
+        "expected": ["THUMPERS", "Unkinder (A Tougher Love)"],
+    },
+    {
+        "input": "Chad VanGaalen - Where Are You?",
+        "expected": ["Chad VanGaalen", "Where Are You?"],
+    },
+    {
+        "input": "Mogwai - The Lord Is Out Of Control [OFFICIAL VIDEO]",
+        "expected": ["Mogwai", "The Lord Is Out Of Control"],
+    },
+    {
+        "input": "Lyla Foy -  Impossible [OFFICIAL PERFORMANCE VIDEO]",
+        "expected": ["Lyla Foy", "Impossible"],
+    },
+    {
+        "input": "Death Vessel - Ilsa Drown (feat. Jónsi) [not the video]",
+        "expected": ["Death Vessel", "Ilsa Drown (feat. Jónsi)"],
+    },
+    {
+        "input": "The Notwist - Close To The Glass (not the video)",
+        "expected": ["The Notwist", "Close To The Glass"],
+    },
+    {
+        "input": "Dum Dum Girls - Lost Boys And Girls Club [OFFICIAL VIDEO]",
+        "expected": ["Dum Dum Girls", "Lost Boys And Girls Club"],
+    },
+]
+
+
+class TestSequence(with_metaclass(TestSequenceMeta, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2 

Bring feature tests to parity with [get-artist-title](https://github.com/goto-bus-stop/get-artist-title). Not too surprisingly, 33/128 tests are failing at the moment. But it should now be a lot easier to identify the issues with the code. Will address them in a later PR.