### PR TITLE
Return None, None tuple on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![PyPI version shields.io](https://img.shields.io/pypi/v/youtube-title-parse.svg)](https://pypi.org/project/youtube-title-parse/)
 [![PyPI license](https://img.shields.io/pypi/l/youtube-title-parse.svg)](https://pypi.org/project/youtube-title-parse/)
 [![PyPI status](https://img.shields.io/pypi/status/youtube-title-parse.svg)](https://pypi.org/project/youtube-title-parse/)
@@ -14,7 +13,8 @@ Video titles on YouTube follow no strict format, and so passing the titles direc
 
 ## Installation
 
-To install [youtube\_title\_parse](https://pypi.python.org/pypi/youtube-title-parse/), simply run:
+To install [youtube_title_parse](https://pypi.python.org/pypi/youtube-title-parse/), simply run:
+
 ```bash
 pip install youtube_title_parse
 ```
@@ -33,6 +33,7 @@ Seoul - Stay With Us
 ### Module
 
 You can also import `youtube_title_parse` as a module.
+If the module can successfully parse the input, `get_artist_title` will return a tuple of the format `[artist, title]` which you can use as below. If not found, `[None, None]` is returned.
 
 ```python
 from youtube_title_parse import get_artist_title

--- a/test/meta.py
+++ b/test/meta.py
@@ -23,9 +23,9 @@ class MetaTestSequence(type):
                 if "options" in test_params:
                     artist, title = get_artist_title(
                         input, options=test_params["options"]
-                    ) or (None, None)
+                    )
                 else:
-                    artist, title = get_artist_title(input) or (None, None)
+                    artist, title = get_artist_title(input)
                 self.assertEqual(title, expected[1])
                 self.assertEqual(artist, expected[0])
 

--- a/test/test_unsupported.py
+++ b/test/test_unsupported.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import unittest
+from six import with_metaclass
+from .meta import MetaTestSequence
+
+tests = [
+    # https://www.youtube.com/watch?v=vuOAZtc9z3c
+    {
+        "input": "Cinnamon Rolls",
+        "expected": [None, None],
+    },
+    # https://www.youtube.com/watch?v=axYc-NpvZWg
+    {
+        "input": "Some Sand",
+        "expected": [None, None],
+    },
+]
+
+
+class TestSequence(with_metaclass(MetaTestSequence, unittest.TestCase)):
+    test_cases = tests
+    test_type = __file__
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/youtube_title_parse/parse.py
+++ b/youtube_title_parse/parse.py
@@ -33,7 +33,7 @@ def get_artist_title(text, options={}):
     if result:
         return result[0], result[1]
     else:
-        return None
+        return None, None
 
 
 def process(args):


### PR DESCRIPTION
Currently, using this module would look like:
```py
artist, title = get_artist_title(input) or (None, None)
```
which isn't ideal. A much cleaner approach would be to use it as:
```py
artist, title = get_artist_title(input)
```

Support this functionality by returning a None type tuple even on failures.